### PR TITLE
style with styler

### DIFF
--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -87,10 +87,10 @@ with_handlers <- function(.expr, ...) {
     abort("all handlers should inherit from `exiting` or `inplace`")
   }
   if (length(exiting)) {
-    quo <- quo(tryCatch(!! quo, !!! exiting))
+    quo <- quo(tryCatch(!!quo, !!!exiting))
   }
   if (length(inplace)) {
-    quo <- quo(withCallingHandlers(!! quo, !!! inplace))
+    quo <- quo(withCallingHandlers(!!quo, !!!inplace))
   }
 
   eval_tidy(quo)

--- a/R/cnd-restarts.R
+++ b/R/cnd-restarts.R
@@ -106,7 +106,7 @@
 #' # You can use restarting() to create restarting handlers easily:
 #' with_handlers(fn(FALSE), default_empty_string = restarting("rst_null"))
 with_restarts <- function(.expr, ...) {
-  quo <- quo(withRestarts(expr = !! enquo(.expr), !!! dots_list(...)))
+  quo <- quo(withRestarts(expr = !!enquo(.expr), !!!dots_list(...)))
   eval_tidy(quo)
 }
 

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -67,32 +67,40 @@ message_cnd <- function(.type = NULL, ..., .msg = NULL) {
 #' @export
 new_cnd <- function(.type = NULL, ..., .msg = NULL) {
   # Deprecated in 0.1.2
-  warning("`new_cnd()` has been renamed to `cnd()` for consistency",
-    call. = FALSE)
+  warning(
+    "`new_cnd()` has been renamed to `cnd()` for consistency",
+    call. = FALSE
+  )
   cnd(.type = .type, ..., .msg = .msg)
 }
 #' @rdname deprecated-cnd
 #' @export
 cnd_error <- function(.type = NULL, ..., .msg = NULL) {
   # Deprecated in 0.1.2
-  warning("`cnd_error()` has been renamed to `error_cnd()` for consistency",
-    call. = FALSE)
+  warning(
+    "`cnd_error()` has been renamed to `error_cnd()` for consistency",
+    call. = FALSE
+  )
   error_cnd(.type = .type, ..., .msg = .msg)
 }
 #' @rdname deprecated-cnd
 #' @export
 cnd_warning <- function(.type = NULL, ..., .msg = NULL) {
   # Deprecated in 0.1.2
-  warning("`cnd_warning()` has been renamed to `warning_cnd()` for consistency",
-    call. = FALSE)
+  warning(
+    "`cnd_warning()` has been renamed to `warning_cnd()` for consistency",
+    call. = FALSE
+  )
   warning_cnd(.type = .type, ..., .msg = .msg)
 }
 #' @rdname deprecated-cnd
 #' @export
 cnd_message <- function(.type = NULL, ..., .msg = NULL) {
   # Deprecated in 0.1.2
-  warning("`cnd_message()` has been renamed to `message_cnd()` for consistency",
-    call. = FALSE)
+  warning(
+    "`cnd_message()` has been renamed to `message_cnd()` for consistency",
+    call. = FALSE
+  )
   message_cnd(.type = .type, ..., .msg = .msg)
 }
 

--- a/R/compat-lazyeval.R
+++ b/R/compat-lazyeval.R
@@ -24,7 +24,8 @@ compat_lazy <- function(lazy, env = caller_env(), warn = TRUE) {
     return(quo())
   }
 
-  coerce_type(lazy, "a quosure",
+  coerce_type(
+    lazy, "a quosure",
     formula = as_quosure(lazy, env),
     symbol = ,
     language = new_quosure(lazy, env),
@@ -43,7 +44,8 @@ compat_lazy <- function(lazy, env = caller_env(), warn = TRUE) {
       new_quosure(lazy, env)
     },
     list =
-      coerce_class(lazy, "a quosure",
+      coerce_class(
+        lazy, "a quosure",
         lazy = new_quosure(lazy$expr, lazy$env)
       )
   )

--- a/R/compat-oldrel.R
+++ b/R/compat-oldrel.R
@@ -8,7 +8,6 @@
 # their way to the next R version) -----------------------------------
 
 if (TRUE || utils::packageVersion("base") < "3.4.0") {
-
   captureArg <- function(x, strict = TRUE) {
     caller_env <- parent.frame()
 
@@ -31,14 +30,12 @@ if (TRUE || utils::packageVersion("base") < "3.4.0") {
 
     .Call(rlang_capturedots, NULL, NULL, pairlist(caller_env, strict), get_env())
   }
-
 }
 
 
 # R 3.2.0 ------------------------------------------------------------
 
 if (utils::packageVersion("base") < "3.2.0") {
-
   dir_exists <- function(path) {
     !identical(path, "") && file.exists(paste0(path, .Platform$file.sep))
   }
@@ -53,7 +50,6 @@ if (utils::packageVersion("base") < "3.2.0") {
       base::names(x)
     }
   }
-
 }
 
 # nocov end

--- a/R/dots.R
+++ b/R/dots.R
@@ -97,8 +97,7 @@ dots_clean_empty <- function(dots, is_empty, ignore_empty) {
 
   if (n_dots) {
     which <- match.arg(ignore_empty, c("trailing", "none", "all"))
-    switch(
-      which,
+    switch(which,
       trailing =
         if (is_empty(dots[[n_dots]])) {
           dots[[n_dots]] <- NULL

--- a/R/dots.R
+++ b/R/dots.R
@@ -97,7 +97,8 @@ dots_clean_empty <- function(dots, is_empty, ignore_empty) {
 
   if (n_dots) {
     which <- match.arg(ignore_empty, c("trailing", "none", "all"))
-    switch(which,
+    switch(
+      which,
       trailing =
         if (is_empty(dots[[n_dots]])) {
           dots[[n_dots]] <- NULL

--- a/R/env.R
+++ b/R/env.R
@@ -176,7 +176,8 @@ new_environment <- function(data = list()) {
 #' # With NULL it returns the empty environment:
 #' as_env(NULL)
 as_env <- function(x, parent = NULL) {
-  coerce_type(x, "an environment",
+  coerce_type(
+    x, "an environment",
     NULL = {
       empty_env()
     },
@@ -266,7 +267,7 @@ env_tail <- function(env = caller_env()) {
   env_ <- get_env(env)
   next_env <- parent.env(env_)
 
-  while(!is_empty_env(next_env)) {
+  while (!is_empty_env(next_env)) {
     env_ <- next_env
     next_env <- parent.env(next_env)
   }
@@ -279,7 +280,7 @@ env_parents <- function(env = caller_env()) {
   out <- list_len(env_depth(env))
 
   i <- 1L
-  while(!is_empty_env(env)) {
+  while (!is_empty_env(env)) {
     env <- env_parent(env)
     out[[i]] <- env
     i <- i + 1L
@@ -306,7 +307,7 @@ env_depth <- function(env) {
   env_ <- get_env(env)
 
   n <- 0L
-  while(!is_empty_env(env_)) {
+  while (!is_empty_env(env_)) {
     env_ <- env_parent(env_)
     n <- n + 1L
   }
@@ -367,7 +368,8 @@ is_empty_env <- function(env) {
 #' default <- env()
 #' identical(get_env(f, default), default)
 get_env <- function(env = caller_env(), default = NULL) {
-  out <- switch_type(env,
+  out <- switch_type(
+    env,
     environment = env,
     definition = ,
     formula = attr(env, ".Environment"),
@@ -411,7 +413,8 @@ get_env <- function(env = caller_env(), default = NULL) {
 #' fn <- set_env(fn, other_env)
 #' identical(get_env(fn), other_env)
 set_env <- function(env, new_env = caller_env()) {
-  switch_type(env,
+  switch_type(
+    env,
     definition = ,
     formula = ,
     closure = {
@@ -692,7 +695,7 @@ env_unbind <- function(env = caller_env(), nms, inherit = FALSE) {
   env_ <- get_env(env)
 
   if (inherit) {
-    while(any(env_has(env_, nms, inherit = TRUE))) {
+    while (any(env_has(env_, nms, inherit = TRUE))) {
       rm(list = nms, envir = env, inherits = TRUE)
     }
   } else {
@@ -795,7 +798,7 @@ scope_set <- function(env, nm, value, create) {
   env_ <- get_env(env)
   cur <- env_
 
-  while(!env_has(cur, nm) && !is_empty_env(cur)) {
+  while (!env_has(cur, nm) && !is_empty_env(cur)) {
     cur <- env_parent(cur)
   }
 
@@ -880,7 +883,7 @@ env_inherits <- function(env, ancestor) {
   env <- get_env(env)
   stopifnot(is_env(ancestor) && is_env(env))
 
-  while(!is_empty_env(env_parent(env))) {
+  while (!is_empty_env(env_parent(env))) {
     env <- env_parent(env)
     if (is_reference(env, ancestor)) {
       return(TRUE)
@@ -1095,7 +1098,8 @@ env_type <- function(env) {
   }
 }
 friendly_env_type <- function(type) {
-  switch(type,
+  switch(
+    type,
     global = "the global environment",
     empty = "the empty environment",
     base = "the base environment",

--- a/R/env.R
+++ b/R/env.R
@@ -1098,8 +1098,7 @@ env_type <- function(env) {
   }
 }
 friendly_env_type <- function(type) {
-  switch(
-    type,
+  switch(type,
     global = "the global environment",
     empty = "the empty environment",
     base = "the base environment",

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -228,7 +228,7 @@ as_overscope <- function(quo, data = NULL) {
 
   # Emulate dynamic scope for established data
   if (is_vector(data)) {
-    bottom <- env_bury(bottom, !!! discard_unnamed(data))
+    bottom <- env_bury(bottom, !!!discard_unnamed(data))
   } else if (is_env(data)) {
     bottom <- env_clone(data, parent = bottom)
   } else if (!is_null(data)) {
@@ -305,7 +305,7 @@ overscope_clean <- function(overscope) {
   # At this level we only want to remove what we have installed
   env_unbind(overscope, c("~", ".top_env", ".env"))
 
-  while(!identical(cur_env, env_parent(top_env))) {
+  while (!identical(cur_env, env_parent(top_env))) {
     env_unbind(cur_env, names(cur_env))
     cur_env <- env_parent(cur_env)
   }

--- a/R/eval.R
+++ b/R/eval.R
@@ -178,7 +178,7 @@ invoke <- function(.fn, .args = list(), ...,
     if (is_scalar_character(.fn)) {
       .fn <- env_get(.env, .fn, inherit = TRUE)
     }
-    call <- lang(.fn, !!! args)
+    call <- lang(.fn, !!!args)
     return(.Call(r_eval, call, .env))
   }
 
@@ -191,15 +191,15 @@ invoke <- function(.fn, .args = list(), ...,
 
   buried_nms <- paste0(arg_prefix, seq_along(args))
   buried_args <- set_names(args, buried_nms)
-  .env <- env_bury(.env, !!! buried_args)
+  .env <- env_bury(.env, !!!buried_args)
   args <- set_names(buried_nms, names(args))
   args <- syms(args)
 
   if (is_function(.fn)) {
-    env_bind(.env, !! fn_nm := .fn)
+    env_bind(.env, !!fn_nm := .fn)
     .fn <- fn_nm
   }
 
-  call <- lang(.fn, !!! args)
+  call <- lang(.fn, !!!args)
   .Call(r_eval, call, .env)
 }

--- a/R/expr-lang.R
+++ b/R/expr-lang.R
@@ -388,7 +388,8 @@ lang_fn <- function(lang) {
     abort("`lang` must quote a lang")
   }
 
-  switch_lang(expr,
+  switch_lang(
+    expr,
     recursive = abort("`lang` does not lang a named or inlined function"),
     inlined = node_car(expr),
     named = ,
@@ -426,7 +427,8 @@ lang_name <- function(lang) {
     abort("`lang` must be a call or must wrap a call (e.g. in a quosure)")
   }
 
-  switch_lang(lang,
+  switch_lang(
+    lang,
     named = as_string(node_car(lang)),
     namespaced = as_string(node_cadr(node_cdar(lang))),
     NULL

--- a/R/expr-node.R
+++ b/R/expr-node.R
@@ -249,7 +249,7 @@ duplicate <- function(x, shallow = FALSE) {
 
 node_walk <- function(.x, .f, ...) {
   cur <- .x
-  while(!is.null(cur)) {
+  while (!is.null(cur)) {
     .f(cur, ...)
     cur <- node_cdr(cur)
   }
@@ -258,7 +258,7 @@ node_walk <- function(.x, .f, ...) {
 node_walk_nonnull <- function(.x, .f, ...) {
   cur <- .x
   out <- NULL
-  while(!is.null(cur) && is.null(out)) {
+  while (!is.null(cur) && is.null(out)) {
     out <- .f(cur, ...)
     cur <- node_cdr(cur)
   }
@@ -266,7 +266,7 @@ node_walk_nonnull <- function(.x, .f, ...) {
 }
 node_walk_last <- function(.x, .f, ...) {
   cur <- .x
-  while(!is.null(node_cdr(cur))) {
+  while (!is.null(node_cdr(cur))) {
     cur <- node_cdr(cur)
   }
   .f(cur, ...)

--- a/R/expr.R
+++ b/R/expr.R
@@ -243,7 +243,8 @@ expr_label <- function(expr) {
 #' @rdname expr_label
 #' @export
 expr_name <- function(expr) {
-  switch_type(expr,
+  switch_type(
+    expr,
     symbol = as_string(expr),
     quosure = ,
     language = {

--- a/R/fn.R
+++ b/R/fn.R
@@ -386,8 +386,7 @@ as_closure <- function(x, env = caller_env()) {
 }
 
 op_as_closure <- function(prim_nm) {
-  switch(
-    prim_nm,
+  switch(prim_nm,
     `<-` = ,
     `<<-` = ,
     `=` = function(.x, .y) {

--- a/R/fn.R
+++ b/R/fn.R
@@ -280,7 +280,7 @@ is_primitive_lazy <- function(x) {
 #' fn_env(fn) <- other_env
 #' identical(fn_env(fn), other_env)
 fn_env <- function(fn) {
-  if(!is_function(fn)) {
+  if (!is_function(fn)) {
     abort("`fn` is not a function", "type")
   }
   environment(fn)
@@ -289,7 +289,7 @@ fn_env <- function(fn) {
 #' @export
 #' @rdname fn_env
 `fn_env<-` <- function(x, value) {
-  if(!is_function(x)) {
+  if (!is_function(x)) {
     abort("`fn` is not a function", "type")
   }
   environment(x) <- value
@@ -332,7 +332,8 @@ fn_env <- function(fn) {
 #' as_closure(`+`)
 #' as_closure(`~`)
 as_function <- function(x, env = caller_env()) {
-  coerce_type(x, friendly_type("function"),
+  coerce_type(
+    x, friendly_type("function"),
     primitive = ,
     closure = {
       x
@@ -353,7 +354,8 @@ as_function <- function(x, env = caller_env()) {
 #' @export
 as_closure <- function(x, env = caller_env()) {
   x <- as_function(x, env = env)
-  coerce_type(x, "a closure",
+  coerce_type(
+    x, "a closure",
     closure =
       x,
     primitive = {
@@ -384,7 +386,8 @@ as_closure <- function(x, env = caller_env()) {
 }
 
 op_as_closure <- function(prim_nm) {
-  switch(prim_nm,
+  switch(
+    prim_nm,
     `<-` = ,
     `<<-` = ,
     `=` = function(.x, .y) {
@@ -406,7 +409,7 @@ op_as_closure <- function(prim_nm) {
       eval_bare(expr, caller_env())
     },
     `[<-` = function(.x, ...) {
-      expr <- expr(`[<-`(!! enexpr(.x), !!! exprs(...)))
+      expr <- expr(`[<-`(!!enexpr(.x), !!!exprs(...)))
       eval_bare(expr, caller_env())
     },
     `(` = function(.x) .x,
@@ -433,7 +436,7 @@ op_as_closure <- function(prim_nm) {
     `>=` = function(.x, .y) .x >= .y,
     `==` = function(.x, .y) .x == .y,
     `!=` = function(.x, .y) .x != .y,
-    `:` = function(.x, .y) .x : .y,
+    `:` = function(.x, .y) .x:.y,
     `~` = function(.x, .y) {
       if (is_missing(substitute(.y))) {
         new_formula(NULL, substitute(.x), caller_env())

--- a/R/formula.R
+++ b/R/formula.R
@@ -149,7 +149,7 @@ copy_lang_name <- function(f, x) {
 #' @export
 #' @rdname f_rhs
 f_env <- function(f) {
-  if(!is_formula(f)) {
+  if (!is_formula(f)) {
     abort("`f` must be a formula")
   }
   attr(f, ".Environment")

--- a/R/quo.R
+++ b/R/quo.R
@@ -461,7 +461,8 @@ quo_name <- function(quo) {
 }
 
 quo_splice <- function(x, parent = NULL, warn = FALSE) {
-  switch_expr(x,
+  switch_expr(
+    x,
     language = {
       if (is_quosure(x)) {
         if (!is_false(warn)) {
@@ -486,7 +487,7 @@ quo_splice <- function(x, parent = NULL, warn = FALSE) {
       }
     },
     pairlist = {
-      while(!is_null(x)) {
+      while (!is_null(x)) {
         quo_splice(node_car(x), x, warn = warn)
         x <- node_cdr(x)
       }

--- a/R/quos.R
+++ b/R/quos.R
@@ -8,7 +8,7 @@
 #' definition expressions of the type `var := expr`, with some
 #' differences:
 #'
-#'\describe{
+#' \describe{
 #'  \item{`quos()`}{
 #'    When `:=` definitions are supplied to `quos()`, they are treated
 #'    as a synonym of argument assignment `=`. On the other hand, they

--- a/R/stack.R
+++ b/R/stack.R
@@ -236,7 +236,6 @@ trail_next <- function(callers, i, clean) {
       callers <- callers[-special_eval_pos]
       i <- i - 1L
     }
-
   }
 
   list(callers = callers, i = i)

--- a/R/types.R
+++ b/R/types.R
@@ -484,8 +484,7 @@ friendly_type <- function(type) {
 }
 
 friendly_type_of <- function(type) {
-  switch(
-    type,
+  switch(type,
     logical = "a logical vector",
     integer = "an integer vector",
     numeric = ,
@@ -523,8 +522,7 @@ friendly_type_of <- function(type) {
 }
 
 friendly_lang_type_of <- function(type) {
-  switch(
-    type,
+  switch(type,
     named = "a named call",
     namespaced = "a namespaced call",
     recursive = "a recursive call",
@@ -533,8 +531,7 @@ friendly_lang_type_of <- function(type) {
 }
 
 friendly_expr_type_of <- function(type) {
-  switch(
-    type,
+  switch(type,
     NULL = "NULL",
     name = ,
     symbol = "a symbol",

--- a/R/types.R
+++ b/R/types.R
@@ -484,7 +484,8 @@ friendly_type <- function(type) {
 }
 
 friendly_type_of <- function(type) {
-  switch(type,
+  switch(
+    type,
     logical = "a logical vector",
     integer = "an integer vector",
     numeric = ,
@@ -522,7 +523,8 @@ friendly_type_of <- function(type) {
 }
 
 friendly_lang_type_of <- function(type) {
-  switch(type,
+  switch(
+    type,
     named = "a named call",
     namespaced = "a namespaced call",
     recursive = "a recursive call",
@@ -531,7 +533,8 @@ friendly_lang_type_of <- function(type) {
 }
 
 friendly_expr_type_of <- function(type) {
-  switch(type,
+  switch(
+    type,
     NULL = "NULL",
     name = ,
     symbol = "a symbol",
@@ -667,7 +670,8 @@ lang_type_of <- function(x) {
 #' structure(quote(foo), foo = "bar")
 #' quote(foo)
 is_copyable <- function(x) {
-  switch_type(x,
+  switch_type(
+    x,
     NULL = ,
     char = ,
     symbol = ,

--- a/R/vector-chr.R
+++ b/R/vector-chr.R
@@ -98,7 +98,8 @@ as_native_character <- function(x) {
 #' @rdname as_utf8_character
 #' @export
 as_utf8_string <- function(x) {
-  coerce_type(x, "an UTF-8 string",
+  coerce_type(
+    x, "an UTF-8 string",
     symbol = ,
     string = enc2utf8(as_string(x))
   )
@@ -106,7 +107,8 @@ as_utf8_string <- function(x) {
 #' @rdname as_utf8_character
 #' @export
 as_native_string <- function(x) {
-  coerce_type(x, "a natively encoded string",
+  coerce_type(
+    x, "a natively encoded string",
     symbol = ,
     string = enc2native(as_string(x))
   )

--- a/R/vector-coercion.R
+++ b/R/vector-coercion.R
@@ -104,7 +104,8 @@ NULL
 #' @rdname vector-coercion
 #' @export
 as_logical <- function(x) {
-  coerce_type_vec(x, friendly_type("logical"),
+  coerce_type_vec(
+    x, friendly_type("logical"),
     logical = set_attrs(x, NULL),
     integer = as_base_type(x, as.logical),
     double = as_integerish_type(x, as.logical, "logical")
@@ -113,7 +114,8 @@ as_logical <- function(x) {
 #' @rdname vector-coercion
 #' @export
 as_integer <- function(x) {
-  coerce_type_vec(x, friendly_type("integer"),
+  coerce_type_vec(
+    x, friendly_type("integer"),
     logical = as_base_type(x, as.integer),
     integer = set_attrs(x, NULL),
     double = as_integerish_type(x, as.integer, "integer")
@@ -122,7 +124,8 @@ as_integer <- function(x) {
 #' @rdname vector-coercion
 #' @export
 as_double <- function(x) {
-  coerce_type_vec(x, friendly_type("double"),
+  coerce_type_vec(
+    x, friendly_type("double"),
     logical = ,
     integer = as_base_type(x, as.double),
     double = set_attrs(x, NULL)
@@ -131,7 +134,8 @@ as_double <- function(x) {
 #' @rdname vector-coercion
 #' @export
 as_complex <- function(x) {
-  coerce_type_vec(x, friendly_type("complex"),
+  coerce_type_vec(
+    x, friendly_type("complex"),
     logical = ,
     integer = ,
     double = as_base_type(x, as.complex),
@@ -141,7 +145,8 @@ as_complex <- function(x) {
 #' @rdname vector-coercion
 #' @export
 as_character <- function(x, encoding = NULL) {
-  coerce_type_vec(x, friendly_type("character"),
+  coerce_type_vec(
+    x, friendly_type("character"),
     string = ,
     character = set_chr_encoding(set_attrs(x, NULL), encoding)
   )
@@ -149,7 +154,8 @@ as_character <- function(x, encoding = NULL) {
 #' @rdname vector-coercion
 #' @export
 as_string <- function(x, encoding = NULL) {
-  x <- coerce_type(x, friendly_type("string"),
+  x <- coerce_type(
+    x, friendly_type("string"),
     symbol = {
       if (!is.null(encoding)) {
         warn("`encoding` argument ignored for symbols")
@@ -163,7 +169,8 @@ as_string <- function(x, encoding = NULL) {
 #' @rdname vector-coercion
 #' @export
 as_list <- function(x) {
-  switch_type(x,
+  switch_type(
+    x,
     environment = env_as_list(x),
     vec_as_list(x)
   )
@@ -174,7 +181,8 @@ env_as_list <- function(x) {
   set_names(x, .Call(rlang_unescape_character, names_x))
 }
 vec_as_list <- function(x) {
-  coerce_type_vec(x, friendly_type("list"),
+  coerce_type_vec(
+    x, friendly_type("list"),
     logical = ,
     integer = ,
     double = ,

--- a/R/vector-raw.R
+++ b/R/vector-raw.R
@@ -18,8 +18,7 @@ new_bytes <- function(x) {
 #' @return A raw vector of bytes.
 #' @export
 as_bytes <- function(x) {
-  switch(
-    typeof(x),
+  switch(typeof(x),
     raw = return(x),
     character = if (is_string(x)) return(charToRaw(x))
   )

--- a/R/vector-raw.R
+++ b/R/vector-raw.R
@@ -18,7 +18,8 @@ new_bytes <- function(x) {
 #' @return A raw vector of bytes.
 #' @export
 as_bytes <- function(x) {
-  switch(typeof(x),
+  switch(
+    typeof(x),
     raw = return(x),
     character = if (is_string(x)) return(charToRaw(x))
   )

--- a/tests/testthat/helper-stack.R
+++ b/tests/testthat/helper-stack.R
@@ -1,7 +1,7 @@
 
 fixup_calls <- function(x) {
   cur_pos <- sys.nframe() - 1
-  x[seq(n+1, length(x))]
+  x[seq(n + 1, length(x))]
 }
 
 fixup_ctxt_depth <- function(x) {

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -13,10 +13,13 @@ test_that("chr_append() appends", {
 test_that("r_warn() signals", {
   handler <- function(c) expect_null(c$call)
 
-  expect_warning(regexp = "foo",
-    with_handlers(warning = inplace(handler),
+  expect_warning(
+    regexp = "foo",
+    with_handlers(
+      warning = inplace(handler),
       .Call(rlang_test_r_warn, "foo")
-    ))
+    )
+  )
 })
 
 test_that("r_on_exit() adds deferred expr", {

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -11,7 +11,8 @@ test_that("cnd() throws with unnamed fields", {
 })
 
 test_that("cnd_signal() creates muffle restarts", {
-  withCallingHandlers(cnd_signal("foo", .mufflable = TRUE),
+  withCallingHandlers(
+    cnd_signal("foo", .mufflable = TRUE),
     foo = function(c) {
       expect_true(rst_exists("muffle"))
       expect_is(c, "mufflable")
@@ -105,7 +106,8 @@ test_that("error when msg is not a string", {
 context("restarts") # ------------------------------------------------
 
 test_that("restarts are established", {
-  with_restarts(foo = function() {}, expect_true(rst_exists("foo")))
+  with_restarts(foo = function() {
+  }, expect_true(rst_exists("foo")))
 })
 
 
@@ -116,17 +118,25 @@ test_that("Local handlers can muffle mufflable conditions", {
   muffling_handler <- inplace(function(c) NULL, muffle = TRUE)
   non_muffling_handler <- inplace(function(c) NULL, muffle = FALSE)
 
-  expect_error(regexp = "not muffled!",
+  expect_error(
+    regexp = "not muffled!",
     withCallingHandlers(foo = function(c) stop("not muffled!"), {
-      withCallingHandlers(foo = non_muffling_handler,
-        signal_mufflable())
-    }))
+      withCallingHandlers(
+        foo = non_muffling_handler,
+        signal_mufflable()
+      )
+    })
+  )
 
-  expect_error(regexp = NA,
+  expect_error(
+    regexp = NA,
     withCallingHandlers(foo = function(c) stop("not muffled!"), {
-      withCallingHandlers(foo = muffling_handler,
-        signal_mufflable())
-    }))
+      withCallingHandlers(
+        foo = muffling_handler,
+        signal_mufflable()
+      )
+    })
+  )
 })
 
 test_that("with_handlers() establishes inplace and exiting handlers", {
@@ -140,8 +150,14 @@ test_that("with_handlers() establishes inplace and exiting handlers", {
   expect_equal(with_handlers(identity(letters), splice(handlers)), identity(letters))
   expect_equal(with_handlers(stop(letters), splice(handlers)), "caught error")
   expect_equal(with_handlers(message(letters), splice(handlers)), "caught message")
-  expect_warning(expect_equal(with_handlers({ warning("warn!"); letters }, splice(handlers)), identity(letters)), "warn!")
-  expect_output(expect_equal(with_handlers({ cnd_signal("foobar"); letters }, splice(handlers)), identity(letters)), "foobar")
+  expect_warning(expect_equal(with_handlers({
+    warning("warn!")
+    letters
+  }, splice(handlers)), identity(letters)), "warn!")
+  expect_output(expect_equal(with_handlers({
+    cnd_signal("foobar")
+    letters
+  }, splice(handlers)), identity(letters)), "foobar")
 })
 
 test_that("set_names2() fills in empty names", {
@@ -157,7 +173,8 @@ test_that("restarting() handlers pass along all requested arguments", {
     with_handlers(signal_foo(), foo = restart_handler)
   }
 
-  restart_handler <- restarting("rst_foo",
+  restart_handler <- restarting(
+    "rst_foo",
     a = "a",
     splice(list(b = "b")),
     .fields = c(field_arg = "foo_field")

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -9,7 +9,7 @@ test_that("dots are retrieved from arguments", {
 })
 
 test_that("exprs() captures empty arguments", {
-  expect_identical(exprs(, , .ignore_empty = "none"), set_names(list(missing_arg(), missing_arg()), c("", "")))
+  expect_identical(exprs(,, .ignore_empty = "none"), set_names(list(missing_arg(), missing_arg()), c("", "")))
 })
 
 test_that("dots are always named", {
@@ -19,11 +19,11 @@ test_that("dots are always named", {
 })
 
 test_that("dots can be spliced", {
-  expect_identical(dots_values(!!! list(letters)), named_list(splice(list(letters))))
-  expect_identical(flatten(dots_values(!!! list(letters))), list(letters))
-  expect_identical(ll(!!! list(letters)), list(letters))
+  expect_identical(dots_values(!!!list(letters)), named_list(splice(list(letters))))
+  expect_identical(flatten(dots_values(!!!list(letters))), list(letters))
+  expect_identical(ll(!!!list(letters)), list(letters))
   wrapper <- function(...) ll(...)
-  expect_identical(wrapper(!!! list(letters)), list(letters))
+  expect_identical(wrapper(!!!list(letters)), list(letters))
 })
 
 test_that("interpolation by value does not guard formulas", {
@@ -31,7 +31,7 @@ test_that("interpolation by value does not guard formulas", {
 })
 
 test_that("dots names can be unquoted", {
-  expect_identical(dots_values(!! paste0("foo", "bar") := 10), list(foobar = 10))
+  expect_identical(dots_values(!!paste0("foo", "bar") := 10), list(foobar = 10))
 })
 
 test_that("can take forced dots with strict = FALSE", {

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -19,7 +19,7 @@ test_that("Unicode escapes are always converted to UTF8 characters on roundtrip"
 test_that("Unicode escapes are always converted to UTF8 characters in as_list()", {
   with_non_utf8_locale({
     env <- child_env(empty_env())
-    env_bind(env, !! get_alien_lang_string() := NULL)
+    env_bind(env, !!get_alien_lang_string() := NULL)
     list <- as_list(env)
     expect_identical(names(list), get_alien_lang_string())
   })
@@ -28,7 +28,7 @@ test_that("Unicode escapes are always converted to UTF8 characters in as_list()"
 test_that("Unicode escapes are always converted to UTF8 characters with env_names()", {
   with_non_utf8_locale({
     env <- child_env(empty_env())
-    env_bind(env, !! get_alien_lang_string() := NULL)
+    env_bind(env, !!get_alien_lang_string() := NULL)
     expect_identical(env_names(env), get_alien_lang_string())
   })
 })

--- a/tests/testthat/test-fn.R
+++ b/tests/testthat/test-fn.R
@@ -6,7 +6,9 @@ test_that("new_function equivalent to regular function", {
   }
   attr(f1, "srcref") <- NULL
 
-  f2 <- new_function(alist(x = a + b, y =), quote({x + y}))
+  f2 <- new_function(alist(x = a + b, y = ), quote({
+    x + y
+  }))
 
   expect_equal(f1, f2)
 })

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -98,31 +98,31 @@ test_that("can modify environment", {
 test_that("setting RHS preserves attributes", {
   attrs <- list(foo = "bar", class = "baz")
 
-  f <- set_attrs(~foo, !!! attrs)
+  f <- set_attrs(~foo, !!!attrs)
   f_rhs(f) <- quote(bar)
 
-  expect_identical(f, set_attrs(~bar, !!! attrs))
+  expect_identical(f, set_attrs(~bar, !!!attrs))
 })
 
 test_that("setting LHS preserves attributes", {
   attrs <- list(foo = "bar", class = "baz")
 
-  f <- set_attrs(~foo, !!! attrs)
+  f <- set_attrs(~foo, !!!attrs)
   f_lhs(f) <- quote(bar)
 
-  expect_identical(f, set_attrs(bar ~ foo, !!! attrs))
+  expect_identical(f, set_attrs(bar ~ foo, !!!attrs))
 
   f_lhs(f) <- quote(baz)
-  expect_identical(f, set_attrs(baz ~ foo, !!! attrs))
+  expect_identical(f, set_attrs(baz ~ foo, !!!attrs))
 })
 
 test_that("setting environment preserves attributes", {
   attrs <- list(foo = "bar", class = "baz")
   env <- env()
 
-  f <- set_attrs(~foo, !!! attrs)
+  f <- set_attrs(~foo, !!!attrs)
   f_env(f) <- env
-  expect_identical(f, set_attrs(~foo, !!! attrs, .Environment = env))
+  expect_identical(f, set_attrs(~foo, !!!attrs, .Environment = env))
 })
 
 

--- a/tests/testthat/test-lang-call.R
+++ b/tests/testthat/test-lang-call.R
@@ -114,7 +114,8 @@ test_that("lang_fn() extracts function", {
 
 test_that("Inlined functions return NULL name", {
   call <- quote(fn())
-  call[[1]] <- function() {}
+  call[[1]] <- function() {
+  }
   expect_null(lang_name(call))
 })
 

--- a/tests/testthat/test-lang-expr.R
+++ b/tests/testthat/test-lang-expr.R
@@ -33,7 +33,9 @@ test_that("converts atomics to strings", {
 })
 
 test_that("truncates long calls", {
-  expect_equal(expr_label(quote({ a + b })), "`{\n    ...\n}`")
+  expect_equal(expr_label(quote({
+    a + b
+  })), "`{\n    ...\n}`")
 })
 
 

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -21,4 +21,3 @@ test_that("%|% fails with wrong types", {
   expect_error(c(1L, NA) %|% 2)
   expect_error(c(1, NA) %|% "")
 })
-

--- a/tests/testthat/test-quosure.R
+++ b/tests/testthat/test-quosure.R
@@ -1,13 +1,13 @@
 context("quosure")
 
 test_that("quosures are spliced", {
-  q <- quo(foo(!! quo(bar), !! quo(baz(!! quo(baz), 3))))
+  q <- quo(foo(!!quo(bar), !!quo(baz(!!quo(baz), 3))))
   expect_identical(quo_text(q), "foo(bar, baz(baz, 3))")
 
-  q <- expr_interp(~foo::bar(!! function(x) ...))
+  q <- expr_interp(~foo::bar(!!function(x) ...))
   expect_identical(quo_text(q), "foo::bar(function (x) \n...)")
 
-  q <- quo(!! quo(!! quo(foo(!! quo(!! quo(bar(!! quo(!! quo(!! quo(baz))))))))))
+  q <- quo(!!quo(!!quo(foo(!!quo(!!quo(bar(!!quo(!!quo(!!quo(baz))))))))))
   expect_identical(quo_text(q), "foo(bar(baz))")
 })
 
@@ -22,7 +22,7 @@ test_that("splicing does not affect original quosure", {
 })
 
 test_that("as_quosure() doesn't convert functions", {
-  expect_identical(as_quosure(base::mean), set_env(quo(!! base::mean), empty_env()))
+  expect_identical(as_quosure(base::mean), set_env(quo(!!base::mean), empty_env()))
 })
 
 test_that("as_quosure() coerces formulas", {
@@ -31,5 +31,5 @@ test_that("as_quosure() coerces formulas", {
 
 test_that("quo_expr() warns", {
   expect_warning(regex = NA, quo_expr(quo(foo), warn = TRUE))
-  expect_warning(quo_expr(quo(list(!! quo(foo))), warn = TRUE), "inner quosure")
+  expect_warning(quo_expr(quo(list(!!quo(foo))), warn = TRUE), "inner quosure")
 })

--- a/tests/testthat/test-stack.R
+++ b/tests/testthat/test-stack.R
@@ -198,7 +198,10 @@ test_that("ctxt_stack() subsets n frames", {
   expect_identical(stack_n, stack)
 
   # Get correct eval depth within expect_error()
-  expect_error({ n <- ctxt_depth(); stop() })
+  expect_error({
+    n <- ctxt_depth()
+    stop()
+  })
   expect_error(ctxt_stack(n + 1), "not that many frames")
 })
 
@@ -212,7 +215,10 @@ test_that("call_stack() subsets n frames", {
   expect_identical(stack_n, stack)
 
   # Get correct eval depth within expect_error()
-  expect_error({ n <- call_depth(); stop() })
+  expect_error({
+    n <- call_depth()
+    stop()
+  })
   expect_error(call_stack(n + 1), "not that many frames")
 })
 

--- a/tests/testthat/test-tidy-capture.R
+++ b/tests/testthat/test-tidy-capture.R
@@ -24,12 +24,12 @@ test_that("dots are interpolated", {
   fn <- function(...) {
     baz <- "baz"
     fn_var <- quo(baz)
-    g(..., toupper(!! fn_var))
+    g(..., toupper(!!fn_var))
   }
   g <- function(...) {
     foo <- "foo"
     g_var <- quo(foo)
-    h(toupper(!! g_var), ...)
+    h(toupper(!!g_var), ...)
   }
   h <- function(...) {
     quos(...)
@@ -57,7 +57,7 @@ test_that("dots capture is stack-consistent", {
 })
 
 test_that("splice is consistently recognised", {
-  expect_true(is_splice(quote(!!! list())))
+  expect_true(is_splice(quote(!!!list())))
   expect_true(is_splice(quote(UQS(list()))))
   expect_true(is_splice(quote(rlang::UQS(list()))))
   expect_false(is_splice(quote(ns::UQS(list()))))
@@ -67,7 +67,7 @@ test_that("dots can be spliced in", {
   fn <- function(...) {
     var <- "var"
     list(
-      out = g(!!! quos(...), bar(baz), !!! list(a = var, b = ~foo)),
+      out = g(!!!quos(...), bar(baz), !!!list(a = var, b = ~foo)),
       env = get_env()
     )
   }
@@ -80,14 +80,14 @@ test_that("dots can be spliced in", {
     quo(foo(bar)),
     set_env(quo(bar(baz)), out$env),
     a = quo("var"),
-    b = set_env(quo(!! with_env(out$env, ~foo)), out$env)
+    b = set_env(quo(!!with_env(out$env, ~foo)), out$env)
   )
   expect_identical(out$out, expected)
 })
 
 test_that("spliced dots are wrapped in formulas", {
   args <- alist(x = var, y = foo(bar))
-  expect_identical(quos(!!! args), quos_list(x = quo(var), y = quo(foo(bar))))
+  expect_identical(quos(!!!args), quos_list(x = quo(var), y = quo(foo(bar))))
 })
 
 test_that("dot names are interpolated", {
@@ -100,11 +100,11 @@ test_that("dot names are interpolated", {
 })
 
 test_that("corner cases are handled when interpolating dot names", {
-    var <- na_chr
-    expect_identical(names(quos(!!var := NULL)), na_chr)
+  var <- na_chr
+  expect_identical(names(quos(!!var := NULL)), na_chr)
 
-    var <- NULL
-    expect_error(quos(!!var := NULL), "must be a name or string")
+  var <- NULL
+  expect_error(quos(!!var := NULL), "must be a name or string")
 })
 
 test_that("definitions are interpolated", {
@@ -154,7 +154,7 @@ test_that("can capture empty list of dots", {
 })
 
 test_that("quosures are spliced before serialisation", {
-  quosures <- quos(!! quo(foo(!! quo(bar))), .named = TRUE)
+  quosures <- quos(!!quo(foo(!!quo(bar))), .named = TRUE)
   expect_identical(names(quosures), "foo(bar)")
 })
 
@@ -170,22 +170,22 @@ test_that("empty quosures are forwarded", {
   expect_identical(outer(), quo())
 
   inner <- function(x) enquo(x)
-  outer <- function(x) inner(!! enquo(x))
+  outer <- function(x) inner(!!enquo(x))
   expect_identical(outer(), quo())
 })
 
 test_that("quos() captures missing arguments", {
-  expect_identical(quos(, , .ignore_empty = "none"), quos_list(quo(), quo()), c("", ""))
+  expect_identical(quos(,, .ignore_empty = "none"), quos_list(quo(), quo()), c("", ""))
 })
 
 test_that("quos() ignores missing arguments", {
-  expect_identical(quos(, , "foo", ), quos_list(quo(), quo(), new_quosure("foo", empty_env())))
-  expect_identical(quos(, , "foo", , .ignore_empty = "all"), quos_list(new_quosure("foo", empty_env())))
+  expect_identical(quos(,, "foo", ), quos_list(quo(), quo(), new_quosure("foo", empty_env())))
+  expect_identical(quos(,, "foo",, .ignore_empty = "all"), quos_list(new_quosure("foo", empty_env())))
 })
 
 test_that("quosured literals are forwarded as is", {
-  expect_identical(quo(!! quo(NULL)), new_quosure(NULL, empty_env()))
-  expect_identical(quos(!! quo(10L)), set_names(quos_list(new_quosure(10L, empty_env())), ""))
+  expect_identical(quo(!!quo(NULL)), new_quosure(NULL, empty_env()))
+  expect_identical(quos(!!quo(10L)), set_names(quos_list(new_quosure(10L, empty_env())), ""))
 })
 
 test_that("expr() returns missing argument", {

--- a/tests/testthat/test-vector.R
+++ b/tests/testthat/test-vector.R
@@ -110,7 +110,8 @@ test_that("vectors and names are squashed", {
 })
 
 test_that("bad outer names warn even at depth", {
-  expect_warning(regex = "Outer names",
+  expect_warning(
+    regex = "Outer names",
     expect_identical(squash_dbl(list(list(list(A = c(a = 1))))), c(a = 1))
   )
 })
@@ -172,15 +173,17 @@ test_that("flatten_if() handles external pointers", {
 })
 
 test_that("flatten() splices names", {
-  expect_warning(regexp = "Outer names",
+  expect_warning(
+    regexp = "Outer names",
     expect_identical(
-      flatten(list(a = list(A = TRUE), b = list(B = FALSE))) ,
+      flatten(list(a = list(A = TRUE), b = list(B = FALSE))),
       list(A = TRUE, B = FALSE)
     )
   )
-  expect_warning(regexp = "Outer names",
+  expect_warning(
+    regexp = "Outer names",
     expect_identical(
-      flatten(list(a = list(TRUE), b = list(FALSE))) ,
+      flatten(list(a = list(TRUE), b = list(FALSE))),
       list(TRUE, FALSE)
     )
   )


### PR DESCRIPTION
Styling is done with a version of styler containing both https://github.com/krlmlr/styler/pull/150 and https://github.com/krlmlr/styler/pull/149. 

According to the vignette [programming with dplyr](http://dplyr.tidyverse.org/articles/programming.html), there is no space around bang-bang operators.